### PR TITLE
fix(docs): Update Minecraft wiki references

### DIFF
--- a/Writerside/topics/survival-server/join/join/how-to-join.md
+++ b/Writerside/topics/survival-server/join/join/how-to-join.md
@@ -6,7 +6,7 @@
 
 # Wie kann ich dem Server beitreten?
 
-Du benötigst die [Java-Edition](https://minecraft.fandom.com/wiki/Java_Edition) in der
+Du benötigst die [Java-Edition](https://de.minecraft.wiki/w/Java_Edition) in der
 Version [%required_game_version%](%required_game_version_link%), um auf dem Server spielen zu
 können.
 

--- a/Writerside/topics/survival-server/shops/make/make/make-shop.md
+++ b/Writerside/topics/survival-server/shops/make/make/make-shop.md
@@ -1,9 +1,9 @@
 <show-structure depth="2"/>
 <primary-label ref="survival-closed" />
 
-[gold-block]: https://minecraft.fandom.com/de/wiki/Goldblock "Goldblöcke sind Blöcke, die aus neun Goldbarren hergestellt werden können."
+[gold-block]: https://de.minecraft.wiki/w/Goldblock "Goldblöcke sind Blöcke, die aus neun Goldbarren hergestellt werden können."
 
-[chest]: https://minecraft.fandom.com/de/wiki/Truhe "Truhen sind Blöcke, die zum Lagern von Gegenständen verwendet werden können."
+[chest]: https://de.minecraft.wiki/w/Truhe "Truhen sind Blöcke, die zum Lagern von Gegenständen verwendet werden können."
 
 [create-shop]: create-shop.md "Hier findest du eine Anleitung, wie du einen Shop erstellen kannst."
 

--- a/Writerside/v.list
+++ b/Writerside/v.list
@@ -4,7 +4,7 @@
     <var name="server_ip" value="castcrafter.de"/>
     <var name="required_game_version" value="1.21"/>
     <var name="required_game_version_link"
-         value="https://minecraft.fandom.com/wiki/Java_Edition_1.21"/>
+         value="https://de.minecraft.wiki/w/1.21"/>
     <var name="main_currency" value="CastCoin"/>
     <var name="event_coin" value="EventCoin"/>
     <var name="paycheck" value="500"/>


### PR DESCRIPTION
The Minecraft Fandom wiki has been forked to a new domain: minecraft.wiki. Learn more here: https://de.minecraft.wiki/w/Minecraft_Wiki:Umzug_von_Fandom