### PR TITLE
fix(docs): update survival server pages order

### DIFF
--- a/Writerside/ccs.tree
+++ b/Writerside/ccs.tree
@@ -50,12 +50,13 @@
                     <toc-element topic="armorstand.md"/>
                 </toc-element>
                 <toc-element topic="light-blocks-and-invisible-item-frames-and-globe-banner-pattern.md"/>
-                <toc-element topic="map-downloads.md"/>
+            </toc-element>
+            <toc-element topic="map-downloads.md"/>
         </toc-element>
-    </toc-element>
     <toc-element topic="event-server.topic">
         <toc-element topic="how-to-take-part-in-an-event.md"/>
         <toc-element toc-title="Events">
+            <toc-element topic="limitless-hights-event.md"/>
             <toc-element topic="tilted.md"/>
             <toc-element topic="diamondevent.md"/>
             <toc-element topic="one-chunk.md"/>


### PR DESCRIPTION
for whatever reason the download page was categorised under features -< it is not