### PR TITLE
fix(docs): update survival page order

### DIFF
--- a/Writerside/ccs.tree
+++ b/Writerside/ccs.tree
@@ -50,9 +50,9 @@
                     <toc-element topic="armorstand.md"/>
                 </toc-element>
                 <toc-element topic="light-blocks-and-invisible-item-frames-and-globe-banner-pattern.md"/>
-                <toc-element topic="map-downloads.md"/>
         </toc-element>
-    </toc-element>
+            <toc-element topic="map-downloads.md"/>
+        </toc-element>
     <toc-element topic="event-server.topic">
         <toc-element topic="how-to-take-part-in-an-event.md"/>
         <toc-element toc-title="Events">


### PR DESCRIPTION
for whatever reason the map download page was categorised under features (it is not)