### PR TITLE
fix: update team ranks and member listings for clarity and accuracy

### DIFF
--- a/Writerside/topics/general-server/ranks/ranks-overview.md
+++ b/Writerside/topics/general-server/ranks/ranks-overview.md
@@ -51,7 +51,7 @@ Was sie zu bedeuten haben und welche Aufgabe sie erfüllen, erfährst du auf die
 | ![Supporter Azubi](support-a.png)           | /                                                                                                                                                                                                     |
 | ![Community Manager](community-manager.png) | <ul><li>`Floweryalina`</li><li>`Iloveschnitzel09`</li></ul>                                                                                                                                             |
 | ![Designer](designer.png)                   | <ul><li>`KamiIIe`</li></ul>                                                                                                                                                                           |
-| ![Builder](builder.png)                     | <ul><li>PEKK29</li><li>`Speed_Marc`</li></ul>                                                                                                                                                         |
+| ![Builder](builder.png)                     | <ul><li>`PEKK29`</li><li>`Speed_Marc`</li></ul>                                                                                                                                                         |
 
 ## Bewerbungen {collapsible="true" default-state="collapsed" id="team-application"}
 


### PR DESCRIPTION
This pull request makes minor formatting adjustments and updates to the team ranks overview documentation. The main changes are to the tables listing team ranks and members, improving consistency and updating member lists.

Updates to team ranks and member listings:

* Standardized column alignment in the team ranks and members tables for improved readability. [[1]](diffhunk://#diff-0f0da3bb97c5aba3fd40bf47a36f01fd79b8b72056fdbdf439c6c302eea70d60L25-R28) [[2]](diffhunk://#diff-0f0da3bb97c5aba3fd40bf47a36f01fd79b8b72056fdbdf439c6c302eea70d60L44-R54)
* Added `Floweryalina` to the "Community Manager" rank.
* Added `PEKK29` to the "Builder" rank.