### PR TITLE
fix: update team member listings for accuracy and completeness

### DIFF
--- a/Writerside/topics/general-server/ranks/ranks-overview.md
+++ b/Writerside/topics/general-server/ranks/ranks-overview.md
@@ -49,9 +49,9 @@ Was sie zu bedeuten haben und welche Aufgabe sie erfüllen, erfährst du auf die
 | ![Moderator Azubi](moderation-a.png)        | /                                                                                                                                                                                                     |   
 | ![Supporter](support.png)                   | <ul><li>`BobbyCar2612`</li><li>`bringeis1`</li><li>`Cookiiieee`</li><li>`Danilo888TV`</li><li>`Dorlino_`</li><li>`EinePapiertonne`</li><li>`Koljav`</li><li>`Pingius2031`</li><li>`Timonso`</li></ul> |
 | ![Supporter Azubi](support-a.png)           | /                                                                                                                                                                                                     |
-| ![Community Manager](community-manager.png) | <ul><li>`Floweryalina`</li><li>`Iloveschnitzel09`</li></ul>                                                                                                                                             |
+| ![Community Manager](community-manager.png) | <ul><li>`Floweryalina`</li><li>`Iloveschnitzel09`</li></ul>                                                                                                                                           |
 | ![Designer](designer.png)                   | <ul><li>`KamiIIe`</li></ul>                                                                                                                                                                           |
-| ![Builder](builder.png)                     | <ul><li>`PEKK29`</li><li>`Speed_Marc`</li></ul>                                                                                                                                                         |
+| ![Builder](builder.png)                     | <ul><li>`PEKK29`</li><li>`Skyfox2`</li><li>`Speed_Marc`</li><li>`TatatuckRenegade`</li></ul>                                                                                                          |
 
 ## Bewerbungen {collapsible="true" default-state="collapsed" id="team-application"}
 


### PR DESCRIPTION
This pull request updates the list of team members for the Builder role in the `ranks-overview.md` documentation. The most important change is the addition of two new members to the Builder team.

Team roster update:

* Added `Skyfox2` and `TatatuckRenegade` to the Builder team, expanding the list from two to four members in the `ranks-overview.md` documentation.