### PR TITLE
Fix plot price calculation formula

### DIFF
--- a/Writerside/topics/survival-server/plots/misc/misc/plot-other.md
+++ b/Writerside/topics/survival-server/plots/misc/misc/plot-other.md
@@ -44,7 +44,7 @@ Diese Funktion lässt sich jedoch ein- oder ausschalten.
 <def title="Berechnung des Grundstückes" id="plot-price-calculation">
 
 $$
-p(d) = \max( 4, \frac {d} {600} + \frac {37} {3} )
+p(d) = \max( 4, - \frac {d} {600} + \frac {37} {3} )
 $$
 
 Hierbei gilt:


### PR DESCRIPTION
Correct the formula for plot price calculation, by adding a minus to reflect the decreasing block claim price when the distant to the spawn increases.