### PR TITLE
fix: update premium and priotity queue feature descriptions in rank list

### DIFF
--- a/Writerside/topics/general-server/ranks/rank-list-overview.md
+++ b/Writerside/topics/general-server/ranks/rank-list-overview.md
@@ -208,7 +208,7 @@ Ehemalige Teammitglieder oder andere Spieler, die uns unterstützt haben.
 <deflist>
 <def title="Beschreibung" id="description-premium-plus">
 
-*Soon™*
+Premium ist ein erwerbbarer Rang, der dir zusätzliche Features auf dem Server bietet. Ziel von Premium ist es, dein Spielerlebnis angenehmer und individueller zu gestalten. Dieser Rang ist [hier](https://server.castcrafter.de/shop "%click-more-info%") erhältlich.
 
 </def>
 </deflist>
@@ -218,7 +218,7 @@ Ehemalige Teammitglieder oder andere Spieler, die uns unterstützt haben.
 <deflist>
 <def title="Beschreibung" id="description-premium">
 
-*Soon™*
+Priority ist ein erwerbbarer Rang, der dir beim Verbinden mit den Servern einen Vorteil in der Warteschlange verschafft. Dieser Rang ist [hier](https://server.castcrafter.de/shop "%click-more-info%") erhältlich. 
 
 </def>
 </deflist>


### PR DESCRIPTION
This pull request updates the descriptions for the "Premium" and "Priority" ranks in the `rank-list-overview.md` documentation. The new descriptions provide clearer information about the benefits of each rank and include links to the shop where users can purchase them.

Documentation improvements:

* Updated the "Premium" rank description to explain its benefits and added a link to the shop for purchasing the rank.
* Updated the "Priority" rank description to clarify its queue advantage and provide a shop link for purchase.