### PR TITLE
Update rank list descriptions and clan customization details

### DIFF
--- a/Writerside/topics/general-server/clan/clan-more-info.md
+++ b/Writerside/topics/general-server/clan/clan-more-info.md
@@ -15,3 +15,9 @@ Dicord-Server hinzufügen {id="clan-link-discord"}
 Dieser Link wird dann angezeigt, wenn man sich die [Informationen zum Clan](clan-more-info.md#clan-info) ansieht.
 Indem du deinen Discord-Link zum Clan hinzufügst, erleichterst du es anderen, sich zu verbinden, auszutauschen und Teil eines aktiven Clans zu werden. \
 Das Hinzufügen eines Discord-Links ist erst ab 30 Mitgliedern möglich.
+
+Clan-Chat {id="clan-chat"}
+: Mit dem Befehl `/clanchat <Nachricht>` (oder kurz `/cc <Nachricht>`) schreibst du im internen Clan-Chat. Diese Nachrichten sind ausschließlich für deine Clan-Mitglieder sichtbar und perfekt für die interne Absprache.
+
+Clan-Farbe {id="clan-color"}
+: Mit dem Befehl `/clan options tagcolor foreground <Hex-Code>` passt du die Farbe deines Clan-Tags an. Der Farbcode wird im Hexadezimalformat ohne das `#`-Zeichen angegeben (z. B. `FF0000` für Rot). Dieses Feature steht nur **Clan-Erstellern mit Premium-Status** zur Verfügung.

--- a/Writerside/topics/general-server/clan/clan-more-info.md
+++ b/Writerside/topics/general-server/clan/clan-more-info.md
@@ -17,7 +17,7 @@ Indem du deinen Discord-Link zum Clan hinzufügst, erleichterst du es anderen, s
 Das Hinzufügen eines Discord-Links ist erst ab 30 Mitgliedern möglich.
 
 Clan-Chat {id="clan-chat"}
-: Mit dem Befehl `/clanchat <Nachricht>` (oder kurz `/cc <Nachricht>`) schreibst du im internen Clan-Chat. Diese Nachrichten sind ausschließlich für deine Clan-Mitglieder sichtbar und perfekt für die interne Absprache.
+: Mit dem Befehl `/clanchat <Nachricht>` (oder kurz `/cc <Nachricht>`) schreibst du im internen Clan-Chat. Diese Nachrichten sind ausschließlich für deine Clan-Mitglieder sichtbar und eignen sich perfekt für interne Absprachen.
 
 Clan-Farbe {id="clan-color"}
 : Mit dem Befehl `/clan options tagcolor foreground <Hex-Code>` passt du die Farbe deines Clan-Tags an. Der Farbcode wird im Hexadezimalformat ohne das `#`-Zeichen angegeben (z. B. `FF0000` für Rot). Dieses Feature steht nur **Clan-Erstellern mit Premium-Status** zur Verfügung.

--- a/Writerside/topics/general-server/clan/create-clan.md
+++ b/Writerside/topics/general-server/clan/create-clan.md
@@ -18,4 +18,4 @@ Beispiel {id="clan-creation-example"}
 ![clan info](clan-info-command.png)
 ![clan members](clan-members-tab.png)
 
-> Das Clankürzel wird erst ab einer Anzahl von 10 Clanmitlgiedern hinter den Mitgliedern in der Spielerliste angezeigt.
+> Das Clankürzel wird erst ab einer Anzahl von 10 Clanmitgliedern hinter den Mitgliedern in der Spielerliste angezeigt.

--- a/Writerside/topics/general-server/clan/create-clan.md
+++ b/Writerside/topics/general-server/clan/create-clan.md
@@ -18,4 +18,4 @@ Beispiel {id="clan-creation-example"}
 ![clan info](clan-info-command.png)
 ![clan members](clan-members-tab.png)
 
-> Das Clankürzel wird erst ab einer Anzahl von 30 Clanmitlgiedern hinter den Mitgliedern in der Spielerliste angezeigt.
+> Das Clankürzel wird erst ab einer Anzahl von 10 Clanmitlgiedern hinter den Mitgliedern in der Spielerliste angezeigt.

--- a/Writerside/topics/general-server/ranks/rank-list-overview.md
+++ b/Writerside/topics/general-server/ranks/rank-list-overview.md
@@ -208,7 +208,7 @@ Ehemalige Teammitglieder oder andere Spieler, die uns unterstützt haben.
 <deflist>
 <def title="Beschreibung" id="description-premium-plus">
 
-*Soon™*
+Premium ist ein erwerbbarer Rang, der dir zusätzliche Features auf dem Server bietet. Ziel von Premium ist es, dein Spielerlebnis angenehmer und individueller zu gestalten. Dieser Rang ist [hier](https://server.castcrafter.de/shop "%click-more-info%") erhältlich.
 
 </def>
 </deflist>
@@ -218,7 +218,7 @@ Ehemalige Teammitglieder oder andere Spieler, die uns unterstützt haben.
 <deflist>
 <def title="Beschreibung" id="description-premium">
 
-*Soon™*
+Priority ist ein erwerbbarer Rang, der dir beim Verbinden mit den Servern einen Vorteil in der Warteschlange verschafft. Dieser Rang ist [hier](https://server.castcrafter.de/shop "%click-more-info%") erhältlich. 
 
 </def>
 </deflist>

--- a/Writerside/topics/general-server/ranks/rank-list-overview.md
+++ b/Writerside/topics/general-server/ranks/rank-list-overview.md
@@ -208,7 +208,7 @@ Ehemalige Teammitglieder oder andere Spieler, die uns unterstützt haben.
 <deflist>
 <def title="Beschreibung" id="description-premium-plus">
 
-Premium ist ein erwerbbarer Rang, der dir zusätzliche Features auf dem Server bietet. Ziel von Premium ist es, dein Spielerlebnis angenehmer und individueller zu gestalten. Dieser Rang ist [hier](https://server.castcrafter.de/shop "%click-more-info%") erhältlich.
+Premium ist ein erwerbbarer Rang, der dir zusätzliche Features und Vorteile auf dem Server bietet. Ziel von Premium ist es, dein Spielerlebnis individueller und angenehmer zu gestalten. Du kannst den Rang [hier](https://server.castcrafter.de/shop "%click-more-info%") erwerben.
 
 </def>
 </deflist>

--- a/Writerside/topics/general-server/ranks/rank-list-overview.md
+++ b/Writerside/topics/general-server/ranks/rank-list-overview.md
@@ -214,16 +214,6 @@ Premium ist ein erwerbbarer Rang, der dir zusätzliche Features auf dem Server b
 </deflist>
 </tab>
 
-<tab title="Priority Queue" id="premium">
-<deflist>
-<def title="Beschreibung" id="description-premium">
-
-Priority ist ein erwerbbarer Rang, der dir beim Verbinden mit den Servern einen Vorteil in der Warteschlange verschafft. Dieser Rang ist [hier](https://server.castcrafter.de/shop "%click-more-info%") erhältlich. 
-
-</def>
-</deflist>
-</tab>
-
 <tab title="Veteran" id="veteran">
 <deflist>
 <def title="Beschreibung" id="description-veteran">


### PR DESCRIPTION
This pull request updates and expands the documentation for clan features and server ranks, clarifying existing information and adding details about new commands and premium options. The most important changes are grouped below:

**Clan Features and Commands:**

* Added documentation for the `/clanchat` (or `/cc`) command, allowing players to send messages visible only to their clan members.
* Added instructions for changing the clan tag color using `/clan options tagcolor foreground <Hex-Code>`, a feature available exclusively to clan creators with premium status.

**Clan Requirements and Display:**

* Updated the minimum number of members required for the clan tag to be displayed in the player list from 30 to 10.

**Server Ranks Descriptions:**

* Replaced placeholder descriptions for the "Premium" and "Priority" ranks with detailed explanations, including their benefits and purchase links. [[1]](diffhunk://#diff-8a7ac683bf0ef60cff479ff6808db239b4a4e10d094132b84c1194b5f9de24ecL211-R211) [[2]](diffhunk://#diff-8a7ac683bf0ef60cff479ff6808db239b4a4e10d094132b84c1194b5f9de24ecL221-R221)