### PR TITLE
move rich event to the correct order

### DIFF
--- a/Writerside/ccs.tree
+++ b/Writerside/ccs.tree
@@ -59,6 +59,7 @@
         <toc-element topic="how-to-take-part-in-an-event.md"/>
         <toc-element toc-title="Events">
             <toc-element topic="anarchy2-event.md"/>
+            <toc-element topic="rich-event.md"/>
             <toc-element topic="oneblock-event.md"/>
             <toc-element topic="desert-event.md"/>
             <toc-element topic="randomizer-event.md"/>
@@ -81,7 +82,6 @@
             <toc-element topic="flatworld.md"/>
             <toc-element topic="stoneblock-event.md"/>
             <toc-element topic="anarchy-event.md"/>
-            <toc-element topic="rich-event.md"/>
         </toc-element>
     </toc-element>
   <toc-element topic="rank-overview.topic">


### PR DESCRIPTION
This pull request updates the table of contents structure for the documentation by moving the `rich-event.md` topic to a different position within the "Events" section. This change ensures the topics are organized more logically.

Documentation structure updates:

* Moved the `rich-event.md` entry so that it appears earlier in the "Events" section, before `oneblock-event.md`, instead of after `anarchy-event.md` and `stoneblock-event.md`. [[1]](diffhunk://#diff-7a76c57bcf10173069e006128044f74e21ab7ccbd2383a989a3a27c5c42c073cR62) [[2]](diffhunk://#diff-7a76c57bcf10173069e006128044f74e21ab7ccbd2383a989a3a27c5c42c073cL84)