### PR TITLE
Update anarchy2 event status and reorganize event server topic

### DIFF
--- a/Writerside/topics/event-server/event-server.topic
+++ b/Writerside/topics/event-server/event-server.topic
@@ -19,19 +19,10 @@
                   summary="Wie du an einem Event teilnehmen kannst, erfährst du hier."/>
         </spotlight>
 
-        <primary>
-            <title>Aktuelle Events</title>
-            <card href="anarchy2-event.md" badge="creative"/>
-        </primary>
-
-        <secondary>
-            <title>Kommende Events</title>
-            <card href="building-event.md" badge="creative"/>
-        </secondary>
-
         <misc>
             <cards narrow="true">
                 <title>Bereits stattgefundene Events</title>
+                <card href="anarchy2-event.md" badge="creative" summary="Mehr Informationen"/>
                 <card href="crafting-challenge.md" badge="network" summary="Mehr Informationen"/>
                 <card href="oneblock-event.md" badge="container" summary="Mehr Informationen"/>
                 <card href="randomizer-event.md" badge="search" summary="Mehr Informationen"/>

--- a/Writerside/topics/event-server/events/anarchy2-event.md
+++ b/Writerside/topics/event-server/events/anarchy2-event.md
@@ -1,4 +1,4 @@
-<primary-label ref="event-upcoming"/>
+<primary-label ref="event-held"/>
 <secondary-label ref="anarchy-event-2-mc-version"/>
 <secondary-label ref="anarchy-event-2-date"/>
 


### PR DESCRIPTION
This pull request reorganizes how events are presented in the event server documentation and updates the status of the "Anarchy 2" event. The main changes involve restructuring the event listings and updating event labels to reflect their current status.

Event listing reorganization:

* Removed the "Aktuelle Events" and "Kommende Events" sections, and moved the "anarchy2-event" card to the "Bereits stattgefundene Events" section with a summary for more information. (`Writerside/topics/event-server/event-server.topic`)

Event status update:

* Changed the label for the "Anarchy 2" event from "upcoming" to "held" to indicate that the event has already taken place. (`Writerside/topics/event-server/events/anarchy2-event.md`)