### PR TITLE
Fix manual invalid PR workflow dispatch

### DIFF
--- a/.github/workflows/close_invalid_prs.yml
+++ b/.github/workflows/close_invalid_prs.yml
@@ -17,6 +17,7 @@ jobs:
       - name: Close PRs from Default Branch
         env:
           GH_TOKEN: ${{ github.token }}
+          GH_REPO: ${{ github.repository }}
           DEFAULT_BRANCH: ${{ github.event.repository.default_branch }}
           EVENT_NAME: ${{ github.event_name }}
           CURRENT_PR_NUMBER: ${{ github.event.pull_request.number }}


### PR DESCRIPTION
## Summary

- provide `GH_REPO` explicitly to GitHub CLI commands
- keep the workflow checkout-free while allowing `workflow_dispatch` runs to list and close invalid pull requests

## Root cause

After removing `actions/checkout`, `gh pr list` could no longer infer the repository from a local Git checkout during manual runs. This caused:

```text
failed to run git: fatal: not a git repository
```

GitHub CLI supports the `GH_REPO` environment variable for this exact case, so the workflow now sets it to `${{ github.repository }}`.